### PR TITLE
Add missing tests for receipt_number assignation and last_bill_number mock on invoice generation

### DIFF
--- a/spec/support/services/invoice/finder_support.rb
+++ b/spec/support/services/invoice/finder_support.rb
@@ -6,7 +6,7 @@ class Invoice
       concept_type_id: '3',
       recipient_type_id: '80',
       recipient_number: '20308769608',
-      bill_number: '0003-00000012',
+      bill_number: '0001-00000012',
       bill_type_id: '1',
       total_amount: '3170',
       untaxed_amount: '200',

--- a/spec/support/services/invoice/generator_support.rb
+++ b/spec/support/services/invoice/generator_support.rb
@@ -104,5 +104,21 @@ class Invoice
       sale_point_id: NilClass,
       token: NilClass,
     }.freeze
+
+    def self.next_bill_number
+      data = Hash.from_xml(
+        InvoicesServiceMock.mock(:last_bill_number).response.body,
+      ).dig(
+        'Envelope',
+        'Body',
+        'FECompUltimoAutorizadoResponse',
+        'FECompUltimoAutorizadoResult',
+      )
+
+      sale_point = data['PtoVta'].to_i
+      number = data['CbteNro'].to_i + 1
+
+      "#{format('%0004d', sale_point)}-#{format('%008d', number)}"
+    end
   end
 end


### PR DESCRIPTION
### What was done?

- Add testing for invoice's receipt_number in invoice persistence example (`Invoice::Generator` tests).
- Add testing for the call to the next bill number request on invoice generation (`Invoice::Generator` tests).