### PR TITLE
Add rubocop and coverage badges in README

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -55,3 +55,7 @@ jobs:
       with:
         name: "Test Coverage"
         path: coverage/
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :test do
   gem 'shoulda-matchers', '4.0.0.rc1'
   gem 'should_not'
   gem 'simplecov', require: false
+  gem 'simplecov-lcov', require: false
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,10 +151,6 @@ GEM
     nokogiri (1.12.4)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.4-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.12.4-x86_64-linux)
-      racc (~> 1.4)
     nori (2.6.0)
     parallel (1.20.1)
     parser (3.0.2.0)
@@ -274,6 +270,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.3)
     socksify (1.7.1)
     spring (2.1.1)
@@ -346,6 +343,7 @@ DEPENDENCIES
   should_not
   shoulda-matchers (= 4.0.0.rc1)
   simplecov
+  simplecov-lcov
   spring
   spring-watcher-listen (~> 2.0.0)
   webmock

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![coverage](https://coveralls.io/repos/github/unagisoftware/afip-invoices/badge.svg?branch=master)](https://coveralls.io/github/unagisoftware/afip-invoices)
+[![rubocop](https://github.com/unagisoftware/afip-invoices/actions/workflows/rubocop.yml/badge.svg?event=push)](https://github.com/unagisoftware/afip-invoices/actions/workflows/rubocop.yml)
 ## Introducción
 
 Esta aplicación Rails resuelve la integración con los [web services de AFIP](https://www.afip.gob.ar/ws/) a través de una API JSON. Permite mediante la gestión de entidades facturadoras la posibilidad generar y listar comprobantes. El presente README tiene por finalidad introducir sobre las tecnologías utilizadas, la puesta en marcha, el proceso de deploy y algunos diagramas de flujo para entender el funcionamiento interno de la API.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,23 @@ require 'should_not/rspec'
 require 'shoulda/matchers'
 require 'webmock/rspec'
 require 'simplecov'
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config do |c|
+  c.report_with_single_file = true
+  c.single_report_path = 'coverage/lcov.info'
+end
 
 SimpleCov.start 'rails' do
   add_filter '/app/uploaders/'
   add_filter '/bin/'
   add_filter '/db/'
   add_filter '/spec/'
+
+  SimpleCov.formatter =
+  SimpleCov::Formatter::MultiFormatter.new \
+    [SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter]
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
### Changes

- Add LCOV format to simplecov output. 
- Add a coveralls action to send the lcov report.
- Show a badge for coverage percent and rubocop's check in README. 