### PR TITLE
Fix invoice preview generation when items have no metrit units

### DIFF
--- a/app/services/invoice/builder.rb
+++ b/app/services/invoice/builder.rb
@@ -55,7 +55,7 @@ class Invoice
         unit_price: item[:unit_price],
         quantity: item[:quantity] || 1,
         bonus_percentage: item[:bonus_percentage] || 0,
-        metric_unit: item[:metric_unit] || Invoice::Generator::DEFAULT_ITEM_UNIT,
+        metric_unit: item[:metric_unit] || Invoice::Creator::DEFAULT_ITEM_UNIT,
         iva_aliquot_id: item[:iva_aliquot_id],
       )
     end

--- a/spec/services/invoice/builder_spec.rb
+++ b/spec/services/invoice/builder_spec.rb
@@ -67,5 +67,25 @@ describe Invoice::Builder do
           .to eq(params[:associated_invoices].size)
       end
     end
+
+    context 'when no metric unit is provided for each item' do
+      before do
+        params[:items].each do |item|
+          item[:metric_unit] = nil
+        end
+      end
+
+      it 'builds invoice items with default unit' do
+        invoice = subject.call
+
+        expect(invoice.items).not_to be_empty
+        expect(invoice.items.size).to eq(params[:items].size)
+
+        invoice.items.each do |item|
+          expect(item[:metric_unit]).not_to be_blank
+          expect(item[:metric_unit]).to eq(Invoice::Creator::DEFAULT_ITEM_UNIT)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Problem
Invoice preview generation fails when associated items have no metric unit. This is the output of the error:

```
I, [2022-01-25T12:21:48.453202 #8481]  INFO -- : [d73a819c-dfc7-4677-8e0b-83cd1da4c89e] Started POST "/invoices/export_preview" for 190.188.65.83 at 2022-01-25 12:21:48 +0000
I, [2022-01-25T12:21:48.454951 #8481]  INFO -- : [d73a819c-dfc7-4677-8e0b-83cd1da4c89e] Processing by V1::InvoicesController#export_preview as */*
I, [2022-01-25T12:21:48.455389 #8481]  INFO -- : [d73a819c-dfc7-4677-8e0b-83cd1da4c89e]   Parameters: {"external_id"=>606, "concept_type_id"=>"3", "sale_point_id"=>"4", "recipient_type_id"=>"80", "recipient_number"=>"33585510489", "bill_type_id"=>"2", "service_from"=>"20220120", "service_to"=>"20220120", "due_date"=>"20220120", "created_at"=>"20220120", "net_amount"=>0.0, "untaxed_amount"=>163009.92, "exempt_amount"=>0.0, "tax_amount"=>0.0, "iva_amount"=>0, "total_amount"=>163009.92, "taxes"=>[], "iva"=>[], "items"=>[{"code"=>nil, "description"=>"Cheque Caducado N°90000684", "quantity"=>1.0, "unit_price"=>163009.92, "bonus_percentage"=>0.0, "metric_unit"=>nil, "iva_aliquot_id"=>"99"}], "note"=>"", "cbu"=>"", "alias"=>"", "transmission"=>nil, "associated_invoices"=>[], "bill_number"=>"90000684", "invoice"=>{"created_at"=>"20220120", "bill_type_id"=>"2", "note"=>"", "cbu"=>"", "alias"=>""}}
I, [2022-01-25T12:21:50.018313 #8481]  INFO -- : [d73a819c-dfc7-4677-8e0b-83cd1da4c89e] Completed 500 Internal Server Error in 1563ms (ActiveRecord: 0.0ms | Allocations: 18666)
F, [2022-01-25T12:21:50.018995 #8481] FATAL -- : [d73a819c-dfc7-4677-8e0b-83cd1da4c89e]   
[d73a819c-dfc7-4677-8e0b-83cd1da4c89e] NameError (uninitialized constant Invoice::Generator::DEFAULT_ITEM_UNIT):
[d73a819c-dfc7-4677-8e0b-83cd1da4c89e]   
[d73a819c-dfc7-4677-8e0b-83cd1da4c89e] app/services/invoice/builder.rb:58:in `build_item'
[d73a819c-dfc7-4677-8e0b-83cd1da4c89e] app/services/invoice/builder.rb:48:in `block in build_items'
[d73a819c-dfc7-4677-8e0b-83cd1da4c89e] app/services/invoice/builder.rb:48:in `each'
[d73a819c-dfc7-4677-8e0b-83cd1da4c89e] app/services/invoice/builder.rb:48:in `build_items'
[d73a819c-dfc7-4677-8e0b-83cd1da4c89e] app/services/invoice/builder.rb:23:in `call'
[d73a819c-dfc7-4677-8e0b-83cd1da4c89e] app/controllers/v1/invoices_controller.rb:103:in `export_preview'
```

### Changes
- Fix invoice preview generation when items have no metrit units
- Add tests for invoice preview generation without items' metric units.